### PR TITLE
Avoid folding message reference headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ mail-*.tar
 
 # Temporary files for e.g. tests
 /tmp
+
+.tool-versions

--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -118,6 +118,13 @@ defmodule Mail.Renderers.RFC2822 do
     render_header_value(key, value)
   end
 
+  defp render_header_value(header, value) when header in ["In-Reply-To", "References"] do
+    value
+    |> List.wrap()
+    |> Enum.map(&format_message_id/1)
+    |> Enum.join(" ")
+  end
+
   defp render_header_value(_key, [value | subtypes]),
     do:
       Enum.join([encode_header_value(value, :quoted_printable) | render_subtypes(subtypes)], "; ")
@@ -187,6 +194,10 @@ defmodule Mail.Renderers.RFC2822 do
     |> Enum.reverse()
     |> Enum.join("\r\n")
   end
+
+  defp format_message_id(value) when is_binary(value), do: value
+
+  defp format_message_id(value), do: to_string(value)
 
   # As stated at https://datatracker.ietf.org/doc/html/rfc2047#section-2, encoded words must be
   # split in 76 chars including its surroundings and delimmiters.

--- a/test/mail/renderers/rfc_2822_test.exs
+++ b/test/mail/renderers/rfc_2822_test.exs
@@ -94,6 +94,25 @@ defmodule Mail.Renderers.RFC2822Test do
     assert header == "Subject: Hello World!"
   end
 
+  test "does not fold In-Reply-To header" do
+    message_id = "<" <> String.duplicate("a", 70) <> "@example.com>"
+
+    header = Mail.Renderers.RFC2822.render_header("In-Reply-To", message_id)
+
+    assert header == "In-Reply-To: #{message_id}"
+  end
+
+  test "does not fold References header" do
+    message_ids =
+      1..3
+      |> Enum.map(fn index -> "<id-#{index}-" <> String.duplicate("b", 30) <> "@example.com>" end)
+      |> Enum.join(" ")
+
+    header = Mail.Renderers.RFC2822.render_header("References", message_ids)
+
+    assert header == "References: #{message_ids}"
+  end
+
   test "headers - renders all headers" do
     headers = Mail.Renderers.RFC2822.render_headers(%{"foo" => "bar", "baz" => "qux"})
     assert headers == "Foo: bar\r\nBaz: qux"


### PR DESCRIPTION
## Summary
- ensure In-Reply-To and References headers are rendered without RFC2047 folding
- keep message ids intact by formatting and joining values directly
- cover the behaviour with regression tests for both headers

## Testing
- mix test